### PR TITLE
Traducir "HOME" a "Inicio" en el menú de navegación

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
     <!-- menu -->
     <nav class="main-nav main-container" id="nav">
             <ul class="main-menu">
-                <li class="main-menu__item"><a href="#" class="main-menu__link">HOME</a></li>
+                <li class="main-menu__item"><a href="#" class="main-menu__link">Inicio</a></li>
                 <li class="main-menu__item"><a href="#" class="main-menu__link">DATES AND TRACKS</a></li>
                 <li class="main-menu__item"><a href="#" class="main-menu__link">EVENT DETAILS</a></li>
                 <li class="main-menu__item"><a href="#" class="main-menu__link">THE CARS</a></li>


### PR DESCRIPTION
## Descripción
Este PR traduce la palabra "HOME" a "Inicio" en el menú de navegación principal de la página web, mejorando la experiencia para usuarios hispanohablantes.

## Cambios realizados
- Se modificó el archivo `docs/index.html` para cambiar el texto del enlace de navegación de "HOME" a "Inicio"

## Pruebas realizadas
Se verificó que no hay otras instancias de "HOME" en el código que necesiten ser traducidas.

## Notas adicionales
Este cambio es parte de la localización de la interfaz al español.

@ccreativeproyect can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37f2c46422964c1f9e69d0e0137eefe2)